### PR TITLE
Add --json flag for standalone JSON output

### DIFF
--- a/src/codezoom/cli.py
+++ b/src/codezoom/cli.py
@@ -25,12 +25,18 @@ def main(argv: list[str] | None = None) -> None:
         "--output",
         type=Path,
         default=None,
-        help="Output HTML file path (default: codezoom.html)",
+        help="Output file path (default: codezoom.html, or codezoom.json with --json)",
     )
     parser.add_argument(
         "--name",
         default=None,
         help="Project display name (default: auto-detect from pyproject.toml)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output raw JSON data instead of an interactive HTML visualization",
     )
     parser.add_argument(
         "--open",
@@ -61,4 +67,5 @@ def main(argv: list[str] | None = None) -> None:
         output=args.output,
         name=args.name,
         open_browser=args.open_browser,
+        json_output=args.json_output,
     )

--- a/src/codezoom/pipeline.py
+++ b/src/codezoom/pipeline.py
@@ -10,6 +10,7 @@ from codezoom.analysis import find_class_cycles, find_cycles
 from codezoom.detect import detect_extractors
 from codezoom.model import ProjectGraph
 from codezoom.renderer.html import render_html
+from codezoom.renderer.json import render_json
 
 logger = logging.getLogger(__name__)
 
@@ -191,6 +192,7 @@ def run(
     output: Path | None = None,
     name: str | None = None,
     open_browser: bool = False,
+    json_output: bool = False,
 ) -> Path:
     """Run the full codezoom pipeline and return the output path."""
     project_dir = project_dir.resolve()
@@ -234,8 +236,12 @@ def run(
     graph.cycles = find_cycles(graph.hierarchy) + find_class_cycles(graph.hierarchy)
     logger.debug("Cycles detected: %d", len(graph.cycles))
 
-    out_path = output or (project_dir / "codezoom.html")
-    render_html(graph, out_path)
+    default_name = "codezoom.json" if json_output else "codezoom.html"
+    out_path = output or (project_dir / default_name)
+    if json_output:
+        render_json(graph, out_path)
+    else:
+        render_html(graph, out_path)
 
     logger.info("Generated %s", out_path)
 

--- a/src/codezoom/renderer/_serialize.py
+++ b/src/codezoom/renderer/_serialize.py
@@ -1,0 +1,59 @@
+"""Shared serialization logic for rendering a ProjectGraph."""
+
+from __future__ import annotations
+
+from codezoom.model import ProjectGraph, SymbolData
+
+
+def _symbol_to_dict(sym: SymbolData) -> dict:
+    d: dict = {"name": sym.name, "type": sym.kind}
+    if sym.line is not None:
+        d["lineno"] = sym.line
+    if sym.calls:
+        d["calls"] = sym.calls
+    if sym.inherits:
+        d["inherits"] = sym.inherits
+    if sym.children:
+        d["methods"] = {k: _symbol_to_dict(v) for k, v in sym.children.items()}
+    if sym.visibility is not None:
+        d["visibility"] = sym.visibility
+    if sym.origin is not None:
+        d["origin"] = sym.origin
+    return d
+
+
+def graph_to_dict(graph: ProjectGraph) -> dict:
+    """Convert a *ProjectGraph* to the dictionary representation used by all output formats."""
+    hierarchy: dict = {}
+    function_data: dict = {}
+
+    for node_id, node in graph.hierarchy.items():
+        entry = {
+            "children": node.children,
+            "imports_from": node.imports_from,
+            "imports_to": node.imports_to,
+        }
+        if node.class_deps:
+            entry["class_deps"] = node.class_deps
+        if not node.is_exported:
+            entry["is_exported"] = False
+        hierarchy[node_id] = entry
+        if node.symbols:
+            function_data[node_id] = {
+                k: _symbol_to_dict(v) for k, v in node.symbols.items()
+            }
+
+    external_deps_all = sorted(d.name for d in graph.external_deps)
+    external_deps_direct = sorted(d.name for d in graph.external_deps if d.is_direct)
+
+    return {
+        "project_name": graph.project_name,
+        "root_node_ids": graph.root_node_ids,
+        "hierarchy": hierarchy,
+        "functionData": function_data,
+        "external_deps": external_deps_all,
+        "external_deps_direct": external_deps_direct,
+        "external_deps_graph": graph.external_deps_graph,
+        "module_direct_deps": graph.module_direct_deps,
+        "cycles": graph.cycles,
+    }

--- a/src/codezoom/renderer/html.py
+++ b/src/codezoom/renderer/html.py
@@ -6,70 +6,16 @@ import json
 from pathlib import Path
 from string import Template
 
-from codezoom.model import ProjectGraph, SymbolData
+from codezoom.model import ProjectGraph
+from codezoom.renderer._serialize import graph_to_dict
 
 _TEMPLATE_PATH = Path(__file__).with_name("template.html")
-
-
-def _symbol_to_dict(sym: SymbolData) -> dict:
-    d: dict = {"name": sym.name, "type": sym.kind}
-    if sym.line is not None:
-        d["lineno"] = sym.line
-    if sym.calls:
-        d["calls"] = sym.calls
-    if sym.inherits:
-        d["inherits"] = sym.inherits
-    if sym.children:
-        d["methods"] = {k: _symbol_to_dict(v) for k, v in sym.children.items()}
-    if sym.visibility is not None:
-        d["visibility"] = sym.visibility
-    if sym.origin is not None:
-        d["origin"] = sym.origin
-    return d
-
-
-def _graph_to_json(graph: ProjectGraph) -> str:
-    """Serialize *graph* into the JSON blob consumed by the template JS."""
-    hierarchy: dict = {}
-    function_data: dict = {}
-
-    for node_id, node in graph.hierarchy.items():
-        entry = {
-            "children": node.children,
-            "imports_from": node.imports_from,
-            "imports_to": node.imports_to,
-        }
-        if node.class_deps:
-            entry["class_deps"] = node.class_deps
-        if not node.is_exported:
-            entry["is_exported"] = False
-        hierarchy[node_id] = entry
-        if node.symbols:
-            function_data[node_id] = {
-                k: _symbol_to_dict(v) for k, v in node.symbols.items()
-            }
-
-    external_deps_all = sorted(d.name for d in graph.external_deps)
-    external_deps_direct = sorted(d.name for d in graph.external_deps if d.is_direct)
-
-    data = {
-        "project_name": graph.project_name,
-        "root_node_ids": graph.root_node_ids,
-        "hierarchy": hierarchy,
-        "functionData": function_data,
-        "external_deps": external_deps_all,
-        "external_deps_direct": external_deps_direct,
-        "external_deps_graph": graph.external_deps_graph,
-        "module_direct_deps": graph.module_direct_deps,
-        "cycles": graph.cycles,
-    }
-    return json.dumps(data)
 
 
 def render_html(graph: ProjectGraph, output_path: Path) -> None:
     """Write the interactive HTML visualization to *output_path*."""
     template = Template(_TEMPLATE_PATH.read_text())
-    data_json = _graph_to_json(graph)
+    data_json = json.dumps(graph_to_dict(graph))
     html = template.safe_substitute(DATA_JSON=data_json)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(html)

--- a/src/codezoom/renderer/json.py
+++ b/src/codezoom/renderer/json.py
@@ -1,0 +1,16 @@
+"""Render a ProjectGraph to a standalone JSON file."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codezoom.model import ProjectGraph
+from codezoom.renderer._serialize import graph_to_dict
+
+
+def render_json(graph: ProjectGraph, output_path: Path) -> None:
+    """Write the project structure data to *output_path* as formatted JSON."""
+    data = graph_to_dict(graph)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(data, indent=2) + "\n")

--- a/tests/test_json_renderer.py
+++ b/tests/test_json_renderer.py
@@ -1,0 +1,86 @@
+"""Tests for JSON rendering."""
+
+import json
+
+from codezoom.model import ExternalDep, NodeData, ProjectGraph, SymbolData
+from codezoom.renderer.json import render_json
+
+
+def _sample_graph():
+    """Build a small ProjectGraph for testing."""
+    graph = ProjectGraph(
+        project_name="test-project",
+        root_node_ids=["mypackage"],
+    )
+    graph.hierarchy["mypackage"] = NodeData(
+        children=["mypackage.core", "mypackage.utils"],
+    )
+    graph.hierarchy["mypackage.core"] = NodeData(
+        imports_to=["mypackage.utils"],
+        symbols={
+            "Processor": SymbolData(
+                name="Processor",
+                kind="class",
+                line=10,
+                children={
+                    "run": SymbolData(name="run", kind="method", line=12),
+                },
+            ),
+        },
+    )
+    graph.hierarchy["mypackage.utils"] = NodeData(
+        imports_from=["mypackage.core"],
+        symbols={
+            "helper": SymbolData(name="helper", kind="function", line=1),
+        },
+    )
+    graph.external_deps = [
+        ExternalDep(name="requests", is_direct=True),
+        ExternalDep(name="urllib3", is_direct=False),
+    ]
+    graph.external_deps_graph = {"requests": ["urllib3"]}
+    return graph
+
+
+def test_render_json_creates_valid_json(tmp_path):
+    out = tmp_path / "out.json"
+    render_json(_sample_graph(), out)
+
+    data = json.loads(out.read_text())
+    assert data["project_name"] == "test-project"
+    assert data["root_node_ids"] == ["mypackage"]
+
+
+def test_render_json_hierarchy_keys(tmp_path):
+    out = tmp_path / "out.json"
+    render_json(_sample_graph(), out)
+
+    data = json.loads(out.read_text())
+    assert set(data["hierarchy"]) == {"mypackage", "mypackage.core", "mypackage.utils"}
+
+
+def test_render_json_symbols(tmp_path):
+    out = tmp_path / "out.json"
+    render_json(_sample_graph(), out)
+
+    data = json.loads(out.read_text())
+    fd = data["functionData"]
+    assert "Processor" in fd["mypackage.core"]
+    assert fd["mypackage.core"]["Processor"]["type"] == "class"
+    assert "run" in fd["mypackage.core"]["Processor"]["methods"]
+
+
+def test_render_json_external_deps(tmp_path):
+    out = tmp_path / "out.json"
+    render_json(_sample_graph(), out)
+
+    data = json.loads(out.read_text())
+    assert data["external_deps"] == ["requests", "urllib3"]
+    assert data["external_deps_direct"] == ["requests"]
+    assert data["external_deps_graph"] == {"requests": ["urllib3"]}
+
+
+def test_render_json_creates_parent_dirs(tmp_path):
+    out = tmp_path / "nested" / "dir" / "out.json"
+    render_json(_sample_graph(), out)
+    assert out.exists()


### PR DESCRIPTION
## Summary

- Adds a `--json` CLI flag that writes the project graph as formatted JSON instead of wrapping it in the HTML template
- Extracts the shared serialization logic into `renderer/_serialize.py` so both the HTML and JSON renderers reuse the same `graph_to_dict()` function
- Default output path changes from `codezoom.html` to `codezoom.json` when the flag is used; `-o` still overrides either default

## Motivation

I've been using codezoom to generate project structure data for downstream tooling (feeding codemaps into LLM context, etc.). Currently the only way to get the JSON is to scrape it back out of the HTML with a regex, since it's embedded in a `<script>` tag. This is fragile. Since the data is already fully serialized internally, exposing it as a first-class output format is a small change.

If you'd prefer a different approach to JSON export, feel free to close this — happy either way.

## Usage

```bash
# Existing HTML output (unchanged)
codezoom /path/to/project

# New: standalone JSON
codezoom /path/to/project --json

# JSON to a specific path
codezoom /path/to/project --json -o output.json
```

## Test plan

- [x] All 12 existing tests pass unchanged
- [x] 5 new tests for JSON renderer (valid output, hierarchy keys, symbols, external deps, parent dir creation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)